### PR TITLE
Restore sidebar and appbar styles

### DIFF
--- a/Demo/Shared/MainLayout.razor
+++ b/Demo/Shared/MainLayout.razor
@@ -1,5 +1,6 @@
 ﻿@using MudBlazor
 @inherits LayoutComponentBase
+@inject UserState UserState
 
 <PageTitle>Demo</PageTitle>
 
@@ -14,7 +15,7 @@
     </div>
     <div class="main-content">
         <div class="custom-appbar">
-            <h2>Bienvenido</h2>
+            <h2>Bienvenido@(UserState.Usuario != null ? $" {UserState.Usuario.NombreUsuario}" : "")</h2>
         </div>
         <div class="content-body">
             @Body

--- a/Demo/Shared/MainLayout.razor.css
+++ b/Demo/Shared/MainLayout.razor.css
@@ -7,10 +7,13 @@
 
 .custom-sidebar {
     width: 250px;
-    background-color: rgba(0, 0, 0, 0.65);
+    background-color: rgba(0, 0, 0, 0.6);
     color: white;
     padding: 1rem;
-    position: relative;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
     z-index: 2;
 }
 
@@ -18,11 +21,12 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    margin-left: 250px;
     overflow-y: auto;
 }
 
 .custom-appbar {
-    background-color: rgba(0, 0, 0, 0.65);
+    background-color: black;
     color: white;
     padding: 1rem;
     position: sticky;

--- a/Demo/Shared/NavMenu.razor.css
+++ b/Demo/Shared/NavMenu.razor.css
@@ -1,4 +1,8 @@
 /* Estilos generales de la barra lateral */
+.custom-nav {
+    display: flex;
+    flex-direction: column;
+}
 .navbar-toggler {
     background-color: rgba(255, 255, 255, 0.1);
 }


### PR DESCRIPTION
## Summary
- inject `UserState` into `MainLayout` and show current username in the app bar
- tweak sidebar and appbar styles to match original look
- ensure nav menu layout uses a vertical column

## Testing
- `dotnet test Demo.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685a5cd55b5883259c8191229a149a61