### PR TITLE
Improve layout with semantic tags

### DIFF
--- a/Demo/Shared/MainLayout.razor
+++ b/Demo/Shared/MainLayout.razor
@@ -10,15 +10,15 @@
 <MudSnackbarProvider />
 
 <div class="main-layout">
-    <div class="custom-sidebar">
+    <aside class="custom-sidebar">
         <NavMenu />
-    </div>
+    </aside>
     <div class="main-content">
-        <div class="custom-appbar">
+        <header class="custom-appbar">
             <h2>Bienvenido@(UserState.Usuario != null ? $" {UserState.Usuario.NombreUsuario}" : "")</h2>
-        </div>
-        <div class="content-body">
+        </header>
+        <main class="content-body">
             @Body
-        </div>
+        </main>
     </div>
 </div>

--- a/Demo/Shared/MainLayout.razor.css
+++ b/Demo/Shared/MainLayout.razor.css
@@ -37,3 +37,15 @@
 .content-body {
     padding: 1rem;
 }
+
+@media (max-width: 640px) {
+    .custom-sidebar {
+        position: relative;
+        width: 100%;
+        height: auto;
+    }
+
+    .main-content {
+        margin-left: 0;
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `MainLayout.razor` to use `<aside>`, `<header>` and `<main>`
- keep sidebar fixed and add responsive rule for small screens

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a697c80088325aacb0a78705507fc