### PR TITLE
Auto-update NavMenu when session changes

### DIFF
--- a/Demo/Data/UserState.cs
+++ b/Demo/Data/UserState.cs
@@ -9,6 +9,10 @@ namespace Demo.Data
         private readonly ProtectedSessionStorage _sessionStorage;
         private readonly CinemaDbContext _context;
 
+        public event Action? OnChange;
+
+        private void NotifyStateChanged() => OnChange?.Invoke();
+
         public UserState(ProtectedSessionStorage sessionStorage, CinemaDbContext context)
         {
             _sessionStorage = sessionStorage;
@@ -23,6 +27,7 @@ namespace Demo.Data
             if (storedId.Success && storedId.Value.HasValue)
             {
                 Usuario = await _context.Usuarios.FindAsync(storedId.Value.Value);
+                NotifyStateChanged();
             }
         }
 
@@ -30,12 +35,14 @@ namespace Demo.Data
         {
             Usuario = usuario;
             await _sessionStorage.SetAsync(SessionKey, usuario.Id);
+            NotifyStateChanged();
         }
 
         public async Task Logout()
         {
             Usuario = null;
             await _sessionStorage.DeleteAsync(SessionKey);
+            NotifyStateChanged();
         }
     }
 }

--- a/Demo/Shared/NavMenu.razor
+++ b/Demo/Shared/NavMenu.razor
@@ -2,6 +2,7 @@
 @using Demo.Data.Models
 @inject NavigationManager Nav
 @inject UserState UserState
+@implements IDisposable
 
 <MudNavMenu Class="custom-nav">
     <MudNavLink Href="/" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All" Style="color:white; font-size: 1.2rem;">
@@ -46,5 +47,15 @@
     {
         await UserState.Logout();
         Nav.NavigateTo("/");
+    }
+
+    protected override void OnInitialized()
+    {
+        UserState.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        UserState.OnChange -= StateHasChanged;
     }
 }


### PR DESCRIPTION
## Summary
- notify components when the user session changes
- listen for session changes in `NavMenu` so items refresh automatically

## Testing
- `dotnet build Demo/Demo.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beafca6d883259c13a4ac1bdfb78d